### PR TITLE
Fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0",
-    "illuminate/collections": "^9.26",
+    "illuminate/collections": "^10.14",
     "firebase/php-jwt": "^6.3.0"
   },
   "require-dev": {

--- a/tests/DTO/Measurements/TemperatureTest.php
+++ b/tests/DTO/Measurements/TemperatureTest.php
@@ -156,7 +156,8 @@ class TemperatureTest extends AbstractTestCase
         $data = (clone $this->data)->asKelvin()->asCelsius();
 
         $this->assertIsFloat(actual: $data->getValue());
-        $this->assertEquals(expected: 28.31, actual: $data->getValue());
+
+        $this->assertEqualsWithDelta(expected: 28.31, actual: $data->getValue(), delta: 0.01);
         $this->assertInstanceOf(expected: Celsius::class, actual: $data->getUnit());
         $this->assertEquals(expected: '28.31 °C', actual: (string) $data);
     }

--- a/tests/DTO/Measurements/WindTest.php
+++ b/tests/DTO/Measurements/WindTest.php
@@ -191,7 +191,7 @@ class WindTest extends AbstractTestCase
         $data = (clone $this->data)->asFootPerSecond()->asKilometerPerHour();
 
         $this->assertIsFloat(actual: $data->getValue());
-        $this->assertEquals(expected: 5.4099975347712, actual: $data->getValue());
+        $this->assertEqualsWithDelta(expected: 5.4099975347712, actual: $data->getValue(), delta: 0.01);
         $this->assertInstanceOf(expected: KilometerPerHour::class, actual: $data->getUnit());
         $this->assertEquals(expected: '5.4099975347712 km/h', actual: (string) $data);
     }

--- a/tests/DataSets/DailyTest.php
+++ b/tests/DataSets/DailyTest.php
@@ -51,6 +51,13 @@ class DailyTest extends AbstractTestCase
     protected Day $day;
 
     /**
+     * Period forecast data.
+     *
+     * @var \Rugaard\WeatherKit\DTO\Forecasts\Period
+     */
+    protected Period $period;
+
+    /**
      * Set up test case.
      *
      * @return void


### PR DESCRIPTION
After noticing the discrepancy did not come from your library but from PHPUnit, I found this [thread](https://github.com/sebastianbergmann/phpunit/issues/3159). It inspired the change to use `assertEqualsWithDelta`. I think for the purpose of the tests it's fine to do that but let me know if you think otherwise.